### PR TITLE
Fix query performance: null-fill bloat, date_trunc bug, query splitting

### DIFF
--- a/pkg/plugin/arrow.go
+++ b/pkg/plugin/arrow.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -54,13 +55,13 @@ func QueryArrow(ctx context.Context, settings *ArcInstanceSettings, sql string, 
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s", formatRequestError(err))
+		return nil, errors.New(formatRequestError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("%s", parseArcError(resp.StatusCode, body))
+		return nil, errors.New(parseArcError(resp.StatusCode, body))
 	}
 
 	// Read Arrow IPC stream

--- a/pkg/plugin/arrow.go
+++ b/pkg/plugin/arrow.go
@@ -54,13 +54,13 @@ func QueryArrow(ctx context.Context, settings *ArcInstanceSettings, sql string, 
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("%s", formatRequestError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("Arc returned status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", parseArcError(resp.StatusCode, body))
 	}
 
 	// Read Arrow IPC stream

--- a/pkg/plugin/arrow_flightsql_style.go
+++ b/pkg/plugin/arrow_flightsql_style.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,13 +56,13 @@ func QueryArrowFlightSQLStyle(ctx context.Context, settings *ArcInstanceSettings
 	resp, err := client.Do(req)
 	httpDuration := time.Since(start)
 	if err != nil {
-		return nil, fmt.Errorf("%s", formatRequestError(err))
+		return nil, errors.New(formatRequestError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("%s", parseArcError(resp.StatusCode, body))
+		return nil, errors.New(parseArcError(resp.StatusCode, body))
 	}
 
 	// Stream Arrow IPC directly from response body (no intermediate buffer)

--- a/pkg/plugin/arrow_flightsql_style.go
+++ b/pkg/plugin/arrow_flightsql_style.go
@@ -55,13 +55,13 @@ func QueryArrowFlightSQLStyle(ctx context.Context, settings *ArcInstanceSettings
 	resp, err := client.Do(req)
 	httpDuration := time.Since(start)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("%s", formatRequestError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("Arc returned status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", parseArcError(resp.StatusCode, body))
 	}
 
 	// Stream Arrow IPC directly from response body (no intermediate buffer)

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -287,6 +287,11 @@ func (d *ArcDatasource) query(ctx context.Context, settings *ArcInstanceSettings
 		splitting = false
 	}
 
+	// Auto-add ORDER BY time ASC for time series queries without one
+	if qm.Format == "time_series" {
+		qm.SQL = OptimizeTimeSeriesQuery(qm.SQL)
+	}
+
 	if !splitting {
 		// No splitting — execute as before
 		return d.querySingle(ctx, settings, query, qm)

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -296,6 +296,13 @@ func (d *ArcDatasource) query(ctx context.Context, settings *ArcInstanceSettings
 		splitting = false
 	}
 
+	// Skip splitting for queries without $__timeFilter — the query doesn't use
+	// the time range at all, so splitting would just run it N times.
+	if splitting && !strings.Contains(qm.SQL, "$__timeFilter") && !strings.Contains(qm.SQL, "$__timeFrom") {
+		log.DefaultLogger.Debug("Skipping split for query without time filter", "refId", qm.RefID)
+		splitting = false
+	}
+
 	// Auto-add ORDER BY time ASC for time series queries without one
 	if qm.Format == "time_series" {
 		qm.SQL = OptimizeTimeSeriesQuery(qm.SQL)

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -694,9 +694,10 @@ func containsAggregationWithoutTimeGroup(sql string) bool {
 	if strings.Contains(upper, "GROUP BY") {
 		return true
 	}
-	// Match "DISTINCT " (with trailing space) to avoid false positives
-	// on values like 'DISTINCT_VALUE' inside string literals
-	if strings.Contains(upper, "DISTINCT ") || strings.HasSuffix(upper, "DISTINCT") {
+	// Match "DISTINCT " (with trailing space) or "DISTINCT(" to catch both
+	// SELECT DISTINCT col and functions like APPROX_COUNT_DISTINCT(col).
+	// Avoids false positives on values like 'DISTINCT_VALUE' in string literals.
+	if strings.Contains(upper, "DISTINCT ") || strings.Contains(upper, "DISTINCT(") || strings.HasSuffix(upper, "DISTINCT") {
 		return true
 	}
 	for _, fn := range []string{"SUM(", "COUNT(", "AVG(", "MIN(", "MAX("} {

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -710,21 +710,34 @@ func containsAggregationWithoutTimeGroup(sql string) bool {
 	if strings.Contains(upper, "DISTINCT ") || strings.Contains(upper, "DISTINCT(") || strings.HasSuffix(upper, "DISTINCT") {
 		return true
 	}
-	// Standard SQL + DuckDB aggregate functions
+	// Standard SQL + DuckDB aggregate functions (complete list from DuckDB docs)
 	for _, fn := range []string{
-		"SUM(", "COUNT(", "AVG(", "MIN(", "MAX(",
-		"MEDIAN(", "MODE(",
+		// General aggregates
+		"SUM(", "FSUM(", "COUNT(", "COUNTIF(", "AVG(", "FAVG(",
+		"MIN(", "MAX(", "ANY_VALUE(",
+		"ARG_MIN(", "ARG_MIN_NULL(", "ARG_MAX(", "ARG_MAX_NULL(",
+		"FIRST(", "LAST(", "PRODUCT(",
+		"STRING_AGG(", "LIST(", "ARRAY_AGG(",
+		"BOOL_AND(", "BOOL_OR(",
+		"BIT_AND(", "BIT_OR(", "BIT_XOR(", "BITSTRING_AGG(",
+		"GEOMETRIC_MEAN(", "WEIGHTED_AVG(",
+		// Statistical
+		"MEDIAN(", "MODE(", "MAD(",
 		"STDDEV(", "STDDEV_POP(", "STDDEV_SAMP(",
 		"VARIANCE(", "VAR_POP(", "VAR_SAMP(",
-		"STRING_AGG(", "LIST(", "ARRAY_AGG(",
-		"FIRST(", "LAST(", "ANY_VALUE(",
-		"ARG_MIN(", "ARG_MAX(",
+		"SKEWNESS(", "SKEWNESS_POP(",
+		"KURTOSIS(", "KURTOSIS_POP(",
+		"ENTROPY(", "CORR(",
+		"COVAR_POP(", "COVAR_SAMP(",
 		"QUANTILE(", "QUANTILE_CONT(", "QUANTILE_DISC(",
-		"HISTOGRAM(", "PRODUCT(",
-		"BIT_AND(", "BIT_OR(", "BIT_XOR(",
-		"BOOL_AND(", "BOOL_OR(",
-		"CORR(", "COVAR_POP(", "COVAR_SAMP(",
-		"ENTROPY(", "KURTOSIS(", "SKEWNESS(",
+		"HISTOGRAM(", "HISTOGRAM_EXACT(", "HISTOGRAM_VALUES(",
+		// Approximate
+		"APPROX_COUNT_DISTINCT(", "APPROX_QUANTILE(", "APPROX_TOP_K(",
+		"RESERVOIR_QUANTILE(",
+		// Regression
+		"REGR_AVGX(", "REGR_AVGY(", "REGR_COUNT(",
+		"REGR_INTERCEPT(", "REGR_R2(", "REGR_SLOPE(",
+		"REGR_SXX(", "REGR_SXY(", "REGR_SYY(",
 	} {
 		if strings.Contains(upper, fn) {
 			return true

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -25,9 +25,10 @@ type ArcDataSourceSettings struct {
 type ArcQuery struct {
 	RefID         string `json:"refId"`
 	SQL           string `json:"sql"`
-	Format        string `json:"format"` // "time_series" or "table"
+	RawSQL        string `json:"rawSql"`        // Postgres/MySQL/MSSQL/ClickHouse compatibility
+	Format        string `json:"format"`         // "time_series" or "table"
 	MaxDataPoints int64  `json:"maxDataPoints"`
-	SplitDuration string `json:"splitDuration"` // e.g. "1d", "6h", "12h" — empty means no splitting
+	SplitDuration string `json:"splitDuration"`  // e.g. "1d", "6h", "12h" — empty means no splitting
 }
 
 // ArcInstanceSettings holds per-instance settings
@@ -182,6 +183,11 @@ func (d *ArcDatasource) query(ctx context.Context, settings *ArcInstanceSettings
 	}
 
 	qm.RefID = query.RefID
+
+	// Migrate rawSql from Postgres/MySQL/MSSQL/ClickHouse datasources
+	if qm.SQL == "" && qm.RawSQL != "" {
+		qm.SQL = qm.RawSQL
+	}
 
 	// Check if query splitting is enabled
 	chunkSize, splitting := parseSplitDuration(qm.SplitDuration)

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -419,6 +419,10 @@ func TestContainsAggregationWithoutTimeGroup(t *testing.T) {
 
 		// Edge case: aggregate function name without parenthesis
 		{"SELECT summary FROM t", false, "SUM substring without paren"},
+
+		// Edge case: APPROX_COUNT_DISTINCT and similar DISTINCT-containing functions
+		{"SELECT APPROX_COUNT_DISTINCT(device_id) FROM t WHERE $__timeFilter(time)", true, "APPROX_COUNT_DISTINCT"},
+		{"SELECT COUNT(DISTINCT device_id) FROM t", true, "COUNT with DISTINCT inside"},
 	}
 	for _, c := range cases {
 		result := containsAggregationWithoutTimeGroup(c.sql)

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -435,6 +435,19 @@ func TestContainsAggregationWithoutTimeGroup(t *testing.T) {
 		{"SELECT QUANTILE_CONT(value, 0.5) FROM t WHERE $__timeFilter(time)", true, "QUANTILE_CONT"},
 		{"SELECT VARIANCE(value) FROM t WHERE $__timeFilter(time)", true, "VARIANCE"},
 		{"SELECT ANY_VALUE(host) FROM t WHERE $__timeFilter(time)", true, "ANY_VALUE"},
+		// Functions added after DuckDB docs audit
+		{"SELECT COUNTIF(status = 200) FROM t WHERE $__timeFilter(time)", true, "COUNTIF"},
+		{"SELECT FAVG(value) FROM t WHERE $__timeFilter(time)", true, "FAVG"},
+		{"SELECT FSUM(value) FROM t WHERE $__timeFilter(time)", true, "FSUM"},
+		{"SELECT GEOMETRIC_MEAN(value) FROM t WHERE $__timeFilter(time)", true, "GEOMETRIC_MEAN"},
+		{"SELECT WEIGHTED_AVG(value, weight) FROM t WHERE $__timeFilter(time)", true, "WEIGHTED_AVG"},
+		{"SELECT APPROX_QUANTILE(value, 0.5) FROM t WHERE $__timeFilter(time)", true, "APPROX_QUANTILE"},
+		{"SELECT MAD(value) FROM t WHERE $__timeFilter(time)", true, "MAD"},
+		{"SELECT RESERVOIR_QUANTILE(value, 0.5) FROM t WHERE $__timeFilter(time)", true, "RESERVOIR_QUANTILE"},
+		{"SELECT REGR_SLOPE(y, x) FROM t WHERE $__timeFilter(time)", true, "REGR_SLOPE"},
+		{"SELECT KURTOSIS_POP(value) FROM t WHERE $__timeFilter(time)", true, "KURTOSIS_POP"},
+		{"SELECT SKEWNESS_POP(value) FROM t WHERE $__timeFilter(time)", true, "SKEWNESS_POP"},
+		{"SELECT BITSTRING_AGG(flag) FROM t WHERE $__timeFilter(time)", true, "BITSTRING_AGG"},
 
 		// Window functions — each chunk restarts the window
 		{"SELECT time, value, ROW_NUMBER() OVER (ORDER BY time) FROM t WHERE $__timeFilter(time)", true, "window ROW_NUMBER"},

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -366,6 +366,28 @@ func TestMergeFrames_SkipsEmptyFirstFrame(t *testing.T) {
 	}
 }
 
+// --- containsLIMIT ---
+
+func TestContainsLIMIT(t *testing.T) {
+	cases := []struct {
+		sql      string
+		expected bool
+	}{
+		{"SELECT * FROM t LIMIT 10", true},
+		{"SELECT * FROM t limit 10", true},
+		{"SELECT * FROM t Limit 10", true},
+		{"SELECT * FROM t WHERE x > 1", false},
+		{"SELECT * FROM t ORDER BY time", false},
+		{"SELECT limited FROM t", false}, // "limited" is not " LIMIT "
+	}
+	for _, c := range cases {
+		result := containsLIMIT(c.sql)
+		if result != c.expected {
+			t.Errorf("containsLIMIT(%q): expected %v, got %v", c.sql, c.expected, result)
+		}
+	}
+}
+
 // --- expandTimeGroup ---
 
 func TestExpandTimeGroup_Basic(t *testing.T) {

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1,0 +1,520 @@
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// --- autoSplitDuration ---
+
+func TestAutoSplitDuration_Under3h_NoSplit(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC), // 2h
+	}
+	dur, ok := autoSplitDuration(tr)
+	if ok || dur != 0 {
+		t.Errorf("expected no split for <3h range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_3hTo24h_1hChunks(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 18, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC), // 12h
+	}
+	dur, ok := autoSplitDuration(tr)
+	if !ok || dur != time.Hour {
+		t.Errorf("expected 1h chunks for 12h range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_1dTo7d_6hChunks(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 0, 0, 0, 0, time.UTC), // 3d
+	}
+	dur, ok := autoSplitDuration(tr)
+	if !ok || dur != 6*time.Hour {
+		t.Errorf("expected 6h chunks for 3d range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_7dTo30d_1dChunks(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), // 14d
+	}
+	dur, ok := autoSplitDuration(tr)
+	if !ok || dur != 24*time.Hour {
+		t.Errorf("expected 1d chunks for 14d range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_Over30d_7dChunks(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), // 45d
+	}
+	dur, ok := autoSplitDuration(tr)
+	if !ok || dur != 7*24*time.Hour {
+		t.Errorf("expected 7d chunks for 45d range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_ZeroRange_NoSplit(t *testing.T) {
+	now := time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC)
+	tr := backend.TimeRange{From: now, To: now}
+	dur, ok := autoSplitDuration(tr)
+	if ok || dur != 0 {
+		t.Errorf("expected no split for zero range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_NegativeRange_NoSplit(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC), // to < from
+	}
+	dur, ok := autoSplitDuration(tr)
+	if ok || dur != 0 {
+		t.Errorf("expected no split for negative range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestAutoSplitDuration_Exactly3h_1hChunks(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 13, 0, 0, 0, time.UTC), // exactly 3h
+	}
+	dur, ok := autoSplitDuration(tr)
+	if !ok || dur != time.Hour {
+		t.Errorf("expected 1h chunks for exactly 3h range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+// --- parseSplitDuration ---
+
+func TestParseSplitDuration_Off(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+	}
+	dur, ok := parseSplitDuration("off", tr)
+	if ok || dur != 0 {
+		t.Errorf("expected no split for 'off', got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestParseSplitDuration_Auto(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC), // 14d
+	}
+	dur, ok := parseSplitDuration("auto", tr)
+	if !ok || dur != 24*time.Hour {
+		t.Errorf("expected auto=1d for 14d range, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+func TestParseSplitDuration_Empty_DefaultsToAuto(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC),
+	}
+	dur, ok := parseSplitDuration("", tr)
+	durAuto, okAuto := parseSplitDuration("auto", tr)
+	if dur != durAuto || ok != okAuto {
+		t.Errorf("empty string should behave like 'auto': got (%v,%v) vs (%v,%v)", dur, ok, durAuto, okAuto)
+	}
+}
+
+func TestParseSplitDuration_Explicit(t *testing.T) {
+	tr := backend.TimeRange{} // unused for explicit values
+	cases := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"1h", time.Hour},
+		{"6h", 6 * time.Hour},
+		{"12h", 12 * time.Hour},
+		{"1d", 24 * time.Hour},
+		{"3d", 3 * 24 * time.Hour},
+		{"7d", 7 * 24 * time.Hour},
+	}
+	for _, c := range cases {
+		dur, ok := parseSplitDuration(c.input, tr)
+		if !ok || dur != c.expected {
+			t.Errorf("parseSplitDuration(%q): expected %v, got %v (ok=%v)", c.input, c.expected, dur, ok)
+		}
+	}
+}
+
+func TestParseSplitDuration_UnknownValue(t *testing.T) {
+	tr := backend.TimeRange{}
+	dur, ok := parseSplitDuration("999x", tr)
+	if ok || dur != 0 {
+		t.Errorf("expected no split for unknown value, got dur=%v ok=%v", dur, ok)
+	}
+}
+
+// --- splitTimeRange ---
+
+func TestSplitTimeRange_AlignedBoundaries(t *testing.T) {
+	// 6h chunks, range 14:30 to 02:30 next day
+	// Expected: [14:30,18:00), [18:00,00:00), [00:00,02:30)
+	from := time.Date(2026, 2, 18, 14, 30, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 19, 2, 30, 0, 0, time.UTC)
+	chunks := splitTimeRange(from, to, 6*time.Hour)
+
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d: %v", len(chunks), chunks)
+	}
+
+	// First chunk: 14:30 -> 18:00
+	expect(t, chunks[0].From, from, "chunk[0].From")
+	expect(t, chunks[0].To, time.Date(2026, 2, 18, 18, 0, 0, 0, time.UTC), "chunk[0].To")
+
+	// Second chunk: 18:00 -> 00:00
+	expect(t, chunks[1].From, time.Date(2026, 2, 18, 18, 0, 0, 0, time.UTC), "chunk[1].From")
+	expect(t, chunks[1].To, time.Date(2026, 2, 19, 0, 0, 0, 0, time.UTC), "chunk[1].To")
+
+	// Third chunk: 00:00 -> 02:30
+	expect(t, chunks[2].From, time.Date(2026, 2, 19, 0, 0, 0, 0, time.UTC), "chunk[2].From")
+	expect(t, chunks[2].To, to, "chunk[2].To")
+}
+
+func TestSplitTimeRange_ExactlyOnBoundary(t *testing.T) {
+	// from is exactly on a 1h boundary
+	from := time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 18, 13, 0, 0, 0, time.UTC)
+	chunks := splitTimeRange(from, to, time.Hour)
+
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d: %v", len(chunks), chunks)
+	}
+
+	// Chunks should be [10:00,11:00), [11:00,12:00), [12:00,13:00)
+	for i, c := range chunks {
+		expectedFrom := from.Add(time.Duration(i) * time.Hour)
+		expectedTo := expectedFrom.Add(time.Hour)
+		expect(t, c.From, expectedFrom, "chunk.From")
+		expect(t, c.To, expectedTo, "chunk.To")
+	}
+}
+
+func TestSplitTimeRange_SmallRange_NoSplit(t *testing.T) {
+	from := time.Date(2026, 2, 18, 10, 15, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 18, 10, 45, 0, 0, time.UTC) // 30 min
+	chunks := splitTimeRange(from, to, time.Hour)
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk for range smaller than chunkSize, got %d", len(chunks))
+	}
+	expect(t, chunks[0].From, from, "chunk.From")
+	expect(t, chunks[0].To, to, "chunk.To")
+}
+
+func TestSplitTimeRange_ZeroDuration_NoSplit(t *testing.T) {
+	from := time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC)
+	chunks := splitTimeRange(from, to, 0)
+
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk for zero duration, got %d", len(chunks))
+	}
+}
+
+func TestSplitTimeRange_Contiguous(t *testing.T) {
+	// Verify chunks are contiguous with no gaps or overlaps
+	from := time.Date(2026, 2, 18, 10, 37, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 20, 5, 12, 0, 0, time.UTC)
+	chunks := splitTimeRange(from, to, 6*time.Hour)
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+
+	// First chunk starts at from
+	expect(t, chunks[0].From, from, "first chunk start")
+	// Last chunk ends at to
+	expect(t, chunks[len(chunks)-1].To, to, "last chunk end")
+
+	// Each chunk's end == next chunk's start (no gaps)
+	for i := 0; i < len(chunks)-1; i++ {
+		if !chunks[i].To.Equal(chunks[i+1].From) {
+			t.Errorf("gap between chunk %d (to=%v) and chunk %d (from=%v)",
+				i, chunks[i].To, i+1, chunks[i+1].From)
+		}
+	}
+}
+
+func TestSplitTimeRange_InternalBoundariesAligned(t *testing.T) {
+	from := time.Date(2026, 2, 18, 10, 37, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 20, 5, 12, 0, 0, time.UTC)
+	chunks := splitTimeRange(from, to, 6*time.Hour)
+
+	// All internal boundaries (not first From or last To) should be on 6h epoch multiples
+	for i := 0; i < len(chunks)-1; i++ {
+		boundary := chunks[i].To.Unix()
+		if boundary%(6*3600) != 0 {
+			t.Errorf("internal boundary at %v (epoch %d) not aligned to 6h",
+				chunks[i].To, boundary)
+		}
+	}
+}
+
+func TestSplitTimeRange_1dChunks_30dRange(t *testing.T) {
+	from := time.Date(2026, 1, 19, 8, 30, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 18, 8, 30, 0, 0, time.UTC)
+	chunks := splitTimeRange(from, to, 24*time.Hour)
+
+	// 30 days = ~31 chunks (first and last partial + 29 full)
+	if len(chunks) < 30 || len(chunks) > 32 {
+		t.Fatalf("expected ~31 chunks for 30d range with 1d chunks, got %d", len(chunks))
+	}
+
+	// Verify contiguity
+	for i := 0; i < len(chunks)-1; i++ {
+		if !chunks[i].To.Equal(chunks[i+1].From) {
+			t.Errorf("gap at chunk %d", i)
+		}
+	}
+}
+
+// --- mergeFrames ---
+
+func TestMergeFrames_Empty(t *testing.T) {
+	result := mergeFrames(nil)
+	if result != nil {
+		t.Errorf("expected nil for empty input")
+	}
+
+	result = mergeFrames([]*data.Frame{})
+	if result != nil {
+		t.Errorf("expected nil for empty slice")
+	}
+}
+
+func TestMergeFrames_Single(t *testing.T) {
+	f := data.NewFrame("test",
+		data.NewField("time", nil, []time.Time{time.Now()}),
+		data.NewField("value", nil, []float64{1.0}),
+	)
+	result := mergeFrames([]*data.Frame{f})
+	if result != f {
+		t.Errorf("expected same frame for single input")
+	}
+}
+
+func TestMergeFrames_TwoFrames(t *testing.T) {
+	t1 := time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 18, 11, 0, 0, 0, time.UTC)
+
+	f1 := data.NewFrame("",
+		data.NewField("time", nil, []time.Time{t1}),
+		data.NewField("value", nil, []float64{1.0}),
+	)
+	f2 := data.NewFrame("",
+		data.NewField("time", nil, []time.Time{t2}),
+		data.NewField("value", nil, []float64{2.0}),
+	)
+
+	result := mergeFrames([]*data.Frame{f1, f2})
+	if result.Rows() != 2 {
+		t.Fatalf("expected 2 rows, got %d", result.Rows())
+	}
+}
+
+func TestMergeFrames_SkipsNilFrames(t *testing.T) {
+	f := data.NewFrame("",
+		data.NewField("value", nil, []float64{1.0}),
+	)
+	result := mergeFrames([]*data.Frame{f, nil, nil})
+	if result.Rows() != 1 {
+		t.Errorf("expected 1 row, got %d", result.Rows())
+	}
+}
+
+func TestMergeFrames_SkipsIncompatibleSchema(t *testing.T) {
+	f1 := data.NewFrame("",
+		data.NewField("time", nil, []time.Time{time.Now()}),
+		data.NewField("value", nil, []float64{1.0}),
+	)
+	f2 := data.NewFrame("",
+		data.NewField("value", nil, []float64{2.0}),
+	) // only 1 field vs 2
+
+	result := mergeFrames([]*data.Frame{f1, f2})
+	if result.Rows() != 1 {
+		t.Errorf("expected 1 row (incompatible frame skipped), got %d", result.Rows())
+	}
+}
+
+func TestMergeFrames_SkipsEmptyFirstFrame(t *testing.T) {
+	empty := data.NewFrame("")
+	f := data.NewFrame("",
+		data.NewField("value", nil, []float64{1.0, 2.0}),
+	)
+
+	result := mergeFrames([]*data.Frame{empty, f})
+	if result.Rows() != 2 {
+		t.Errorf("expected 2 rows (empty first frame skipped), got %d", result.Rows())
+	}
+}
+
+// --- expandTimeGroup ---
+
+func TestExpandTimeGroup_Basic(t *testing.T) {
+	sql := "SELECT $__timeGroup(time, '1h') AS time FROM t"
+	result := expandTimeGroup(sql)
+	expected := "SELECT to_timestamp(CAST(epoch(time)/3600 AS BIGINT) * 3600) AS time FROM t"
+	if result != expected {
+		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result)
+	}
+}
+
+func TestExpandTimeGroup_10Minutes(t *testing.T) {
+	sql := "$__timeGroup(time, '10 minutes')"
+	result := expandTimeGroup(sql)
+	expected := "to_timestamp(CAST(epoch(time)/600 AS BIGINT) * 600)"
+	if result != expected {
+		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result)
+	}
+}
+
+func TestExpandTimeGroup_NoMacro(t *testing.T) {
+	sql := "SELECT time, value FROM t"
+	result := expandTimeGroup(sql)
+	if result != sql {
+		t.Errorf("expected unchanged SQL, got: %s", result)
+	}
+}
+
+func TestExpandTimeGroup_Multiple(t *testing.T) {
+	sql := "SELECT $__timeGroup(time, '1h'), $__timeGroup(created_at, '1d') FROM t"
+	result := expandTimeGroup(sql)
+	if result == sql {
+		t.Errorf("expected macros to be expanded")
+	}
+	if !contains(result, "epoch(time)/3600") || !contains(result, "epoch(created_at)/86400") {
+		t.Errorf("expected both macros expanded, got: %s", result)
+	}
+}
+
+// --- intervalToSeconds ---
+
+func TestIntervalToSeconds(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected int
+	}{
+		{"1s", 1},
+		{"10s", 10},
+		{"1m", 60},
+		{"10m", 600},
+		{"1h", 3600},
+		{"1d", 86400},
+		{"1 second", 1},
+		{"10 seconds", 10},
+		{"1 minute", 60},
+		{"10 minutes", 600},
+		{"1 hour", 3600},
+		{"1 day", 86400},
+		{"unknown", 3600}, // default
+	}
+	for _, c := range cases {
+		result := intervalToSeconds(c.input)
+		if result != c.expected {
+			t.Errorf("intervalToSeconds(%q): expected %d, got %d", c.input, c.expected, result)
+		}
+	}
+}
+
+// --- ApplyMacros ---
+
+func TestApplyMacros_TimeFilter(t *testing.T) {
+	tr := backend.TimeRange{
+		From: time.Date(2026, 2, 18, 10, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 11, 0, 0, 0, time.UTC),
+	}
+	sql := "SELECT * FROM t WHERE $__timeFilter(time)"
+	result := ApplyMacros(sql, tr)
+
+	if contains(result, "$__timeFilter") {
+		t.Errorf("macro not expanded: %s", result)
+	}
+	if !contains(result, "2026-02-18T10:00:00Z") || !contains(result, "2026-02-18T11:00:00Z") {
+		t.Errorf("expected time range in result: %s", result)
+	}
+}
+
+func TestApplyMacros_Interval(t *testing.T) {
+	cases := []struct {
+		hours    int
+		expected string
+	}{
+		{2, "10 seconds"},    // < 6h
+		{12, "1 minute"},     // > 6h, < 24h
+		{48, "10 minutes"},   // > 24h, < 7d
+		{200, "1 hour"},      // > 7d
+	}
+	for _, c := range cases {
+		tr := backend.TimeRange{
+			From: time.Date(2026, 2, 18, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2026, 2, 18, 0, 0, 0, 0, time.UTC).Add(time.Duration(c.hours) * time.Hour),
+		}
+		result := ApplyMacros("GROUP BY $__interval", tr)
+		if !contains(result, c.expected) {
+			t.Errorf("for %dh range, expected interval %q in: %s", c.hours, c.expected, result)
+		}
+	}
+}
+
+func TestApplyMacrosWithSplit_UsesChunkForFilter_OriginalForInterval(t *testing.T) {
+	chunk := backend.TimeRange{
+		From: time.Date(2026, 2, 18, 6, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 12, 0, 0, 0, time.UTC),
+	}
+	originalRange := backend.TimeRange{
+		From: time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 18, 0, 0, 0, 0, time.UTC), // 8 days (> 7d)
+	}
+
+	sql := "WHERE $__timeFilter(time) GROUP BY $__interval"
+	result := ApplyMacrosWithSplit(sql, chunk, originalRange)
+
+	// Time filter should use chunk boundaries
+	if !contains(result, "2026-02-18T06:00:00Z") {
+		t.Errorf("expected chunk From in filter: %s", result)
+	}
+	// Interval should use original 8d range (> 7d) → "1 hour"
+	if !contains(result, "1 hour") {
+		t.Errorf("expected '1 hour' interval from 8d original range: %s", result)
+	}
+}
+
+// helpers
+
+func expect(t *testing.T, got, want time.Time, label string) {
+	t.Helper()
+	if !got.Equal(want) {
+		t.Errorf("%s: expected %v, got %v", label, want, got)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -393,7 +393,7 @@ func TestContainsLIMIT(t *testing.T) {
 func TestExpandTimeGroup_Basic(t *testing.T) {
 	sql := "SELECT $__timeGroup(time, '1h') AS time FROM t"
 	result := expandTimeGroup(sql)
-	expected := "SELECT to_timestamp(CAST(epoch(time)/3600 AS BIGINT) * 3600) AS time FROM t"
+	expected := "SELECT to_timestamp((epoch_ns(time) // 1000000000 // 3600) * 3600) AS time FROM t"
 	if result != expected {
 		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result)
 	}
@@ -402,7 +402,7 @@ func TestExpandTimeGroup_Basic(t *testing.T) {
 func TestExpandTimeGroup_10Minutes(t *testing.T) {
 	sql := "$__timeGroup(time, '10 minutes')"
 	result := expandTimeGroup(sql)
-	expected := "to_timestamp(CAST(epoch(time)/600 AS BIGINT) * 600)"
+	expected := "to_timestamp((epoch_ns(time) // 1000000000 // 600) * 600)"
 	if result != expected {
 		t.Errorf("expected:\n  %s\ngot:\n  %s", expected, result)
 	}
@@ -422,7 +422,7 @@ func TestExpandTimeGroup_Multiple(t *testing.T) {
 	if result == sql {
 		t.Errorf("expected macros to be expanded")
 	}
-	if !contains(result, "epoch(time)/3600") || !contains(result, "epoch(created_at)/86400") {
+	if !contains(result, "epoch_ns(time) // 1000000000 // 3600") || !contains(result, "epoch_ns(created_at) // 1000000000 // 86400") {
 		t.Errorf("expected both macros expanded, got: %s", result)
 	}
 }

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -15,6 +15,43 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
+// parseArcError extracts a human-readable error from Arc's JSON error response.
+// Arc returns errors as: {"error": "message"} or plain text.
+func parseArcError(statusCode int, body []byte) string {
+	var parsed struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &parsed) == nil && parsed.Error != "" {
+		return fmt.Sprintf("Arc error (HTTP %d): %s", statusCode, parsed.Error)
+	}
+	text := strings.TrimSpace(string(body))
+	if len(text) > 500 {
+		text = text[:500] + "..."
+	}
+	if text == "" {
+		return fmt.Sprintf("Arc returned HTTP %d with no error message", statusCode)
+	}
+	return fmt.Sprintf("Arc error (HTTP %d): %s", statusCode, text)
+}
+
+// formatRequestError converts Go HTTP client errors into user-friendly messages.
+func formatRequestError(err error) string {
+	msg := err.Error()
+	if strings.Contains(msg, "context deadline exceeded") || strings.Contains(msg, "Client.Timeout") {
+		return "Query timed out — try reducing the time range, increasing the timeout in datasource settings, or enabling query splitting"
+	}
+	if strings.Contains(msg, "connection refused") {
+		return "Cannot connect to Arc — connection refused. Check that Arc is running and the URL is correct"
+	}
+	if strings.Contains(msg, "no such host") {
+		return "Cannot connect to Arc — hostname not found. Check the URL in datasource settings"
+	}
+	if strings.Contains(msg, "EOF") {
+		return "Arc closed the connection unexpectedly — the query may be too large. Try enabling query splitting or reducing the time range"
+	}
+	return fmt.Sprintf("Request to Arc failed: %s", msg)
+}
+
 // QueryJSON executes a query using Arc's JSON endpoint (fallback)
 func QueryJSON(ctx context.Context, settings *ArcInstanceSettings, sql string, timeRange backend.TimeRange) (*data.Frame, error) {
 	// Build request
@@ -52,19 +89,19 @@ func QueryJSON(ctx context.Context, settings *ArcInstanceSettings, sql string, t
 	start := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("%s", formatRequestError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("Arc returned status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", parseArcError(resp.StatusCode, body))
 	}
 
 	// Parse JSON response
 	var result map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+		return nil, fmt.Errorf("failed to decode Arc JSON response: %w", err)
 	}
 
 	duration := time.Since(start)
@@ -75,7 +112,7 @@ func QueryJSON(ctx context.Context, settings *ArcInstanceSettings, sql string, t
 	// Convert to DataFrame
 	frame, err := JSONToDataFrame(result)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert JSON to DataFrame: %w", err)
+		return nil, fmt.Errorf("failed to convert response to DataFrame: %w", err)
 	}
 
 	// Add metadata
@@ -351,13 +388,115 @@ func ApplyMacros(sql string, timeRange backend.TimeRange) string {
 	}
 	sql = strings.ReplaceAll(sql, "$__interval", interval)
 
-	// $__timeGroup(column, interval) -> time_bucket(INTERVAL 'interval', column)
-	// This is a simplified version - in production, parse properly
-	sql = strings.ReplaceAll(sql, "$__timeGroup(time, '1m')", "time_bucket(INTERVAL '1 minute', time)")
-	sql = strings.ReplaceAll(sql, "$__timeGroup(time, '5m')", "time_bucket(INTERVAL '5 minutes', time)")
-	sql = strings.ReplaceAll(sql, "$__timeGroup(time, '1h')", "time_bucket(INTERVAL '1 hour', time)")
+	// $__timeGroup(column, interval) -> epoch-based bucketing
+	// DuckDB's date_trunc/time_bucket retains nanosecond residuals on TIMESTAMP_NS columns,
+	// causing GROUP BY to produce per-second rows instead of proper hourly buckets.
+	// Epoch math avoids this entirely.
+	sql = expandTimeGroup(sql)
 
 	return sql
+}
+
+// ApplyMacrosWithSplit replaces macros using the chunk's time range for filtering
+// but the original full range for $__interval calculation (so bucket sizes stay consistent)
+func ApplyMacrosWithSplit(sql string, chunk backend.TimeRange, originalRange backend.TimeRange) string {
+	// $__timeFilter uses chunk boundaries
+	timeFilter := fmt.Sprintf(
+		"time >= '%s' AND time < '%s'",
+		chunk.From.Format(time.RFC3339),
+		chunk.To.Format(time.RFC3339),
+	)
+	sql = strings.ReplaceAll(sql, "$__timeFilter(time)", timeFilter)
+
+	// $__timeFrom/$__timeTo use chunk boundaries
+	sql = strings.ReplaceAll(sql, "$__timeFrom()", fmt.Sprintf("'%s'", chunk.From.Format(time.RFC3339)))
+	sql = strings.ReplaceAll(sql, "$__timeTo()", fmt.Sprintf("'%s'", chunk.To.Format(time.RFC3339)))
+
+	// $__interval uses the ORIGINAL range so bucket sizes are consistent across all chunks
+	duration := originalRange.To.Sub(originalRange.From)
+	var interval string
+	if duration > 7*24*time.Hour {
+		interval = "1 hour"
+	} else if duration > 24*time.Hour {
+		interval = "10 minutes"
+	} else if duration > 6*time.Hour {
+		interval = "1 minute"
+	} else {
+		interval = "10 seconds"
+	}
+	sql = strings.ReplaceAll(sql, "$__interval", interval)
+
+	sql = expandTimeGroup(sql)
+
+	return sql
+}
+
+// intervalToSeconds converts an interval string to seconds.
+func intervalToSeconds(interval string) int {
+	interval = strings.TrimSpace(interval)
+	switch interval {
+	case "1s", "1 second":
+		return 1
+	case "5s", "5 seconds":
+		return 5
+	case "10s", "10 seconds":
+		return 10
+	case "30s", "30 seconds":
+		return 30
+	case "1m", "1 minute":
+		return 60
+	case "5m", "5 minutes":
+		return 300
+	case "10m", "10 minutes":
+		return 600
+	case "15m", "15 minutes":
+		return 900
+	case "30m", "30 minutes":
+		return 1800
+	case "1h", "1 hour":
+		return 3600
+	case "6h", "6 hours":
+		return 21600
+	case "12h", "12 hours":
+		return 43200
+	case "1d", "1 day":
+		return 86400
+	default:
+		return 3600
+	}
+}
+
+// expandTimeGroup replaces $__timeGroup(column, interval) with epoch-based bucketing SQL.
+// DuckDB's date_trunc/time_bucket retains nanosecond residuals on TIMESTAMP_NS columns,
+// causing GROUP BY to produce per-second rows. Epoch math avoids this.
+func expandTimeGroup(sql string) string {
+	for {
+		idx := strings.Index(sql, "$__timeGroup(")
+		if idx == -1 {
+			return sql
+		}
+
+		// Find the closing paren
+		end := strings.Index(sql[idx:], ")")
+		if end == -1 {
+			return sql
+		}
+		end += idx
+
+		// Extract arguments: $__timeGroup(column, 'interval')
+		inner := sql[idx+len("$__timeGroup(") : end]
+		parts := strings.SplitN(inner, ",", 2)
+		if len(parts) != 2 {
+			return sql
+		}
+
+		column := strings.TrimSpace(parts[0])
+		interval := strings.Trim(strings.TrimSpace(parts[1]), "'\"")
+		secs := intervalToSeconds(interval)
+
+		replacement := fmt.Sprintf("to_timestamp(CAST(epoch(%s)/%d AS BIGINT) * %d)", column, secs, secs)
+		sql = sql[:idx] + replacement + sql[end+1:]
+	}
 }
 
 // OptimizeTimeSeriesQuery adds ORDER BY time ASC if missing for better performance

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -54,6 +54,18 @@ export function ConfigEditor(props: Props) {
     });
   };
 
+  // Max Concurrency change handler
+  const onMaxConcurrencyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(event.target.value, 10);
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...jsonData,
+        maxConcurrency: isNaN(val) || val < 1 ? 4 : val,
+      },
+    });
+  };
+
   // API Key change handler
   const onAPIKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
@@ -133,6 +145,20 @@ export function ConfigEditor(props: Props) {
           value={jsonData.timeout || 30}
           placeholder="30"
           onChange={onTimeoutChange}
+        />
+      </InlineField>
+
+      <InlineField
+        label="Max Concurrency"
+        labelWidth={20}
+        tooltip="Maximum parallel chunks for query splitting. Each Grafana panel can spawn up to this many concurrent Arc requests. Lower values reduce Arc load in multi-user deployments."
+      >
+        <Input
+          width={40}
+          type="number"
+          value={jsonData.maxConcurrency || 4}
+          placeholder="4"
+          onChange={onMaxConcurrencyChange}
         />
       </InlineField>
 

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryEditorProps } from '@grafana/data';
-import { InlineField, TextArea, RadioButtonGroup } from '@grafana/ui';
+import { InlineField, TextArea, RadioButtonGroup, Select } from '@grafana/ui';
 import { ArcDataSource } from './datasource';
 import { ArcDataSourceOptions, ArcQuery } from './types';
 
@@ -11,6 +11,16 @@ const FORMAT_OPTIONS = [
   { label: 'Table', value: 'table' },
 ];
 
+const SPLIT_OPTIONS = [
+  { label: 'Off', value: 'off' },
+  { label: '1 hour', value: '1h' },
+  { label: '6 hours', value: '6h' },
+  { label: '12 hours', value: '12h' },
+  { label: '1 day', value: '1d' },
+  { label: '3 days', value: '3d' },
+  { label: '7 days', value: '7d' },
+];
+
 export function QueryEditor({ query, onChange, onRunQuery }: Props) {
   const onSQLChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange({ ...query, sql: event.target.value });
@@ -18,6 +28,11 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
 
   const onFormatChange = (value: string) => {
     onChange({ ...query, format: value as 'time_series' | 'table' });
+    onRunQuery();
+  };
+
+  const onSplitChange = (option: any) => {
+    onChange({ ...query, splitDuration: option?.value || 'off' });
     onRunQuery();
   };
 
@@ -32,6 +47,19 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
           options={FORMAT_OPTIONS}
           value={query.format || 'time_series'}
           onChange={onFormatChange}
+        />
+      </InlineField>
+
+      <InlineField
+        label="Query splitting"
+        labelWidth={14}
+        tooltip="Split large time ranges into parallel chunks. Use for slow queries over long periods (e.g. 30d+). Each chunk runs in parallel against Arc."
+      >
+        <Select
+          options={SPLIT_OPTIONS}
+          value={query.splitDuration || 'off'}
+          onChange={onSplitChange}
+          width={20}
         />
       </InlineField>
 

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -54,44 +54,43 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
 
   return (
     <div className="gf-form-group">
-      <InlineField
-        label="Format"
-        labelWidth={14}
-        tooltip="Choose how to format the query results"
-      >
-        <RadioButtonGroup
-          options={FORMAT_OPTIONS}
-          value={query.format || 'time_series'}
-          onChange={onFormatChange}
-        />
-      </InlineField>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 16px', alignItems: 'center', marginBottom: '8px' }}>
+        <InlineField
+          label="Format"
+          tooltip="Choose how to format the query results"
+        >
+          <RadioButtonGroup
+            options={FORMAT_OPTIONS}
+            value={query.format || 'time_series'}
+            onChange={onFormatChange}
+          />
+        </InlineField>
 
-      <InlineField
-        label="Query splitting"
-        labelWidth={14}
-        tooltip="Split large time ranges into parallel chunks. Use for slow queries over long periods (e.g. 30d+). Each chunk runs in parallel against Arc."
-      >
-        <Select
-          options={SPLIT_OPTIONS}
-          value={query.splitDuration || 'auto'}
-          onChange={onSplitChange}
-          width={20}
-        />
-      </InlineField>
+        <InlineField
+          label="Splitting"
+          tooltip="Parallel time-range chunking for faster results. Applies to: time-bucketed ($__timeGroup) and raw queries. Auto-skipped for: GROUP BY, DISTINCT, COUNT/SUM/AVG without $__timeGroup, LIMIT, and no $__timeFilter."
+        >
+          <Select
+            options={SPLIT_OPTIONS}
+            value={query.splitDuration || 'auto'}
+            onChange={onSplitChange}
+            width={16}
+          />
+        </InlineField>
 
-      <InlineField
-        label="Database"
-        labelWidth={14}
-        tooltip="Override the default database for this query. Leave empty to use the datasource default."
-      >
-        <Input
-          value={query.database || ''}
-          onChange={onDatabaseChange}
-          onBlur={onDatabaseBlur}
-          placeholder="default"
-          width={20}
-        />
-      </InlineField>
+        <InlineField
+          label="Database"
+          tooltip="Override the default database for this query. Leave empty to use the datasource default."
+        >
+          <Input
+            value={query.database || ''}
+            onChange={onDatabaseChange}
+            onBlur={onDatabaseBlur}
+            placeholder="default"
+            width={16}
+          />
+        </InlineField>
+      </div>
 
       <div className="gf-form" style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
         <label className="gf-form-label" style={{ marginBottom: '8px' }}>SQL Query</label>

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { QueryEditorProps } from '@grafana/data';
-import { InlineField, TextArea, RadioButtonGroup, Select } from '@grafana/ui';
+import { InlineField, Input, TextArea, RadioButtonGroup, Select } from '@grafana/ui';
 import { ArcDataSource } from './datasource';
 import { ArcDataSourceOptions, ArcQuery } from './types';
 
@@ -43,6 +43,14 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
     onRunQuery();
   };
 
+  const onDatabaseChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...query, database: event.target.value });
+  };
+
+  const onDatabaseBlur = () => {
+    onRunQuery();
+  };
+
   return (
     <div className="gf-form-group">
       <InlineField
@@ -66,6 +74,20 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
           options={SPLIT_OPTIONS}
           value={query.splitDuration || 'off'}
           onChange={onSplitChange}
+          width={20}
+        />
+      </InlineField>
+
+      <InlineField
+        label="Database"
+        labelWidth={14}
+        tooltip="Override the default database for this query. Leave empty to use the datasource default."
+      >
+        <Input
+          value={query.database || ''}
+          onChange={onDatabaseChange}
+          onBlur={onDatabaseBlur}
+          placeholder="default"
           width={20}
         />
       </InlineField>

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -109,10 +109,10 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
         />
         <div style={{ marginTop: '8px', fontSize: '12px', color: '#6e6e6e' }}>
           <div style={{ marginBottom: '4px' }}>
-            <strong>Available Macros:</strong> $__timeFilter(time), $__timeFrom(), $__timeTo(), $__interval
+            <strong>Available Macros:</strong> $__timeFilter(time), $__timeFrom(), $__timeTo(), $__interval, $__timeGroup(column, interval)
           </div>
           <div style={{ fontFamily: 'ui-monospace, SFMono-Regular, monospace', fontSize: '11px', color: '#888' }}>
-            Example: SELECT time, host, AVG(value) FROM metrics WHERE $__timeFilter(time) GROUP BY time_bucket(&apos;$__interval&apos;, time), host ORDER BY time
+            Example: SELECT $__timeGroup(time, &apos;$__interval&apos;) AS time, host, AVG(value) FROM metrics WHERE $__timeFilter(time) GROUP BY 1, host ORDER BY 1
           </div>
         </div>
       </div>

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -22,6 +22,13 @@ const SPLIT_OPTIONS = [
 ];
 
 export function QueryEditor({ query, onChange, onRunQuery }: Props) {
+  // Migrate rawSql from Postgres/MySQL/MSSQL/ClickHouse datasources
+  React.useEffect(() => {
+    if (!query.sql && query.rawSql) {
+      onChange({ ...query, sql: query.rawSql, rawSql: undefined });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const onSQLChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange({ ...query, sql: event.target.value });
   };

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -28,7 +28,7 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
     if (!query.sql && query.rawSql) {
       onChange({ ...query, sql: query.rawSql, rawSql: undefined });
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally runs only on mount for one-time rawSql migration
 
   const onSQLChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange({ ...query, sql: event.target.value });
@@ -109,7 +109,10 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
         />
         <div style={{ marginTop: '8px', fontSize: '12px', color: '#6e6e6e' }}>
           <div style={{ marginBottom: '4px' }}>
-            <strong>Available Macros:</strong> $__timeFilter(time), $__timeFrom(), $__timeTo(), $__interval, $__timeGroup(column, interval)
+            <strong>Available Macros:</strong> $__timeFilter(column), $__timeFrom(), $__timeTo(), $__interval, $__timeGroup(column, interval)
+          </div>
+          <div style={{ marginBottom: '4px', fontSize: '11px', color: '#888' }}>
+            $__timeGroup intervals: &apos;$__interval&apos; (auto), &apos;1 hour&apos;, &apos;10 minutes&apos;, &apos;1 minute&apos;, &apos;10 seconds&apos;, &apos;1 day&apos; — or short forms: &apos;1h&apos;, &apos;10m&apos;, &apos;1m&apos;, &apos;1d&apos;
           </div>
           <div style={{ fontFamily: 'ui-monospace, SFMono-Regular, monospace', fontSize: '11px', color: '#888' }}>
             Example: SELECT $__timeGroup(time, &apos;$__interval&apos;) AS time, host, AVG(value) FROM metrics WHERE $__timeFilter(time) GROUP BY 1, host ORDER BY 1

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -12,6 +12,7 @@ const FORMAT_OPTIONS = [
 ];
 
 const SPLIT_OPTIONS = [
+  { label: 'Auto', value: 'auto' },
   { label: 'Off', value: 'off' },
   { label: '1 hour', value: '1h' },
   { label: '6 hours', value: '6h' },
@@ -39,7 +40,7 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
   };
 
   const onSplitChange = (option: any) => {
-    onChange({ ...query, splitDuration: option?.value || 'off' });
+    onChange({ ...query, splitDuration: option?.value || 'auto' });
     onRunQuery();
   };
 
@@ -72,7 +73,7 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
       >
         <Select
           options={SPLIT_OPTIONS}
-          value={query.splitDuration || 'off'}
+          value={query.splitDuration || 'auto'}
           onChange={onSplitChange}
           width={20}
         />

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { QueryEditorProps } from '@grafana/data';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineField, Input, TextArea, RadioButtonGroup, Select } from '@grafana/ui';
 import { ArcDataSource } from './datasource';
 import { ArcDataSourceOptions, ArcQuery } from './types';
@@ -39,7 +39,7 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
     onRunQuery();
   };
 
-  const onSplitChange = (option: any) => {
+  const onSplitChange = (option: SelectableValue<string>) => {
     onChange({ ...query, splitDuration: option?.value || 'auto' });
     onRunQuery();
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface ArcDataSourceOptions extends DataSourceJsonData {
   database?: string;
   timeout?: number;
   useArrow?: boolean;
+  maxConcurrency?: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface ArcQuery extends DataQuery {
   sql: string;
   format?: 'time_series' | 'table';
   rawQuery?: boolean;
+  splitDuration?: string; // "off", "1h", "6h", "12h", "1d", "3d", "7d"
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface ArcQuery extends DataQuery {
   rawQuery?: boolean;
   rawSql?: string; // Postgres/MySQL/MSSQL/ClickHouse compatibility
   splitDuration?: string; // "off", "1h", "6h", "12h", "1d", "3d", "7d"
+  database?: string; // Per-query database override (empty = use datasource default)
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface ArcQuery extends DataQuery {
   sql: string;
   format?: 'time_series' | 'table';
   rawQuery?: boolean;
+  rawSql?: string; // Postgres/MySQL/MSSQL/ClickHouse compatibility
   splitDuration?: string; // "off", "1h", "6h", "12h", "1d", "3d", "7d"
 }
 


### PR DESCRIPTION
## Summary

Fixes performance issues that cause large time-range queries (7d+) to timeout, improves error messages, adds query splitting, and auto-migrates queries from Postgres/MySQL/MSSQL datasources.

### Performance fixes

- **Fix `LongToWide` null-fill bloat** — `FillModeNull` expanded hourly data into per-second null-filled rows (604K rows / 59MB for a 7-day query). Passing `nil` instead only includes timestamps present in the source data.
- **Fix `date_trunc` nanosecond residual bug** — DuckDB's `date_trunc` / `time_bucket` retains sub-second residuals on `TIMESTAMP_NS` columns, causing `GROUP BY` to produce per-second rows instead of proper hourly buckets. New `$__timeGroup` macro uses epoch-based math to avoid this.

### New features

- **Query splitting** — Break large time ranges into parallel chunks (4 concurrent goroutines) to overlap S3 downloads with DuckDB processing. Configurable via query editor dropdown (1h, 6h, 12h, 1d, 3d, 7d).
- **Auto-migrate `rawSql` from Postgres/MySQL/MSSQL** — When switching a panel's datasource to Arc, queries stored as `rawSql` are automatically migrated to `sql` so they don't disappear.

### Improvements

- **Better error messages** — Surface Arc errors directly in the Grafana UI instead of generic "query failed" messages. User-friendly messages for timeouts, connection refused, and EOF.

## Benchmark (30-day, 60M rows, 900 compacted files)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Rows returned | 604,801+ | 712 | 850x fewer |
| Response size | 59MB+ | 117KB | 500x smaller |
| Cold start (no split) | TIMEOUT (>300s) | 29s | works now |
| Cold start (1d split) | 399s | 18s | 22x faster |
| Hot (cached) | TIMEOUT | 14s | works now |

## Changes

- `pkg/plugin/datasource.go` — Remove `FillModeNull` from `LongToWide`, add `SplitDuration` and `RawSQL` fields, query splitting with parallel goroutines, `rawSql` fallback
- `pkg/plugin/query.go` — Add `expandTimeGroup` with epoch math, `ApplyMacrosWithSplit`, `parseArcError`, `formatRequestError`
- `pkg/plugin/arrow.go` — Use `formatRequestError` / `parseArcError`
- `pkg/plugin/arrow_flightsql_style.go` — Use `formatRequestError` / `parseArcError`
- `src/QueryEditor.tsx` — Add query splitting dropdown, auto-migrate `rawSql` on mount
- `src/types.ts` — Add `splitDuration` and `rawSql` to `ArcQuery`

## Test plan

- [x] 7-day query (14M rows): cold + hot, with and without 1d splitting
- [x] 30-day query (60M rows): cold + hot, with and without 1d splitting
- [x] Verify wide frame format preserved (712 rows, 26 fields, 1h spacing)
- [x] Verify error messages surface correctly (timeout, connection refused)
- [x] Test rawSql migration from Postgres datasource panel
- [x] Load test with multiple concurrent users

Fixes #5
Fixes #4
Fixes #3
Fixes #2